### PR TITLE
Call hw.MatrixDriver() with no arguments to use the default parameters.

### DIFF
--- a/hdmi_matrix_controller/cmd.py
+++ b/hdmi_matrix_controller/cmd.py
@@ -32,7 +32,7 @@ def main():
     )
     if args.virtual:
         serial_port = ""
-        driver.driver = hw.MatrixDriver(serial_port)
+        driver.driver = hw.MatrixDriver()
     else:
         serial_port = serial.Serial("/dev/ttyUSB0")  # open serial port
         logging.debug(serial_port.name)


### PR DESCRIPTION
Redoing #10 

Running hdmi-mx in virtual or test mode resulted in an error when calling `hw.MatrixDriver(serial_port)` in `cmd.py`.

`(venv) Meerkat:hdmi_matrix_control shanglin$ hdmi-mx -t Traceback (most recent call last): File "/Users/shanglin/projects/scale17x/hdmi_matrix_control/venv/bin/hdmi-mx", line 10, in <module> sys.exit(main()) File "/Users/shanglin/projects/scale17x/hdmi_matrix_control/venv/lib/python3.6/site-packages/hdmi_matrix_controller/cmd.py", line 35, in main driver.driver = hw.MatrixDriver(serial_port) File "/Users/shanglin/projects/scale17x/hdmi_matrix_control/venv/lib/python3.6/site-packages/hdmi_matrix_controller/hw/matrix.py", line 31, in __init__ assert inputs >= 1, "Expected integral number of inputs" TypeError: '>=' not supported between instances of 'str' and 'int'`

This fix calls `hw.MatrixDriver()` without arguments, which starts hdmi-mx in virtual mode without errors.