### PR TITLE
Added port_exists() method

### DIFF
--- a/hdmi_matrix_controller/hw/matrix.py
+++ b/hdmi_matrix_controller/hw/matrix.py
@@ -70,7 +70,13 @@ class MatrixDriver(threading.Thread):
         self.pending = []
 
     def port_exists(self, port_type, portnum):
-        return portnum >= 0 and portnum < self.inputs
+        if port_type == 'Input':
+            return portnum > 0 and portnum - 1 < self.inputs
+        elif port_type == 'Output':
+            return portnum > 0 and portnum  - 1 < self.outputs
+        else:
+            logging.debug("Invalid port type %s", port_type)
+            return False
 
     def run(self):
         """

--- a/hdmi_matrix_controller/hw/matrix.py
+++ b/hdmi_matrix_controller/hw/matrix.py
@@ -69,6 +69,9 @@ class MatrixDriver(threading.Thread):
             self.outputs[output] = in_chan
         self.pending = []
 
+    def port_exists(self, port_type, portnum):
+        return portnum >= 0 and portnum < self.inputs
+
     def run(self):
         """
         Main thread/looping function


### PR DESCRIPTION
hw/matrix.py was missing the MatrixDriver.port_exists(port_type, portnum) method called in web.py. 