### PR TITLE
Added JSON output

### DIFF
--- a/hdmi_matrix_controller/hw/matrix.py
+++ b/hdmi_matrix_controller/hw/matrix.py
@@ -74,6 +74,15 @@ class MatrixDriver(threading.Thread):
         logging.debug("Invalid port type %s", port_type)
         return False
 
+    def to_json(self):
+        """
+        Returns a dictionary representation of the driver.
+        """
+        return {'name': self.name, \
+                'inputs': self.inputs, \
+                'outputs': self.outputs, \
+                'channels': self.channels}
+
     def run(self):
         """
         Main thread/looping function

--- a/hdmi_matrix_controller/templates/index.html
+++ b/hdmi_matrix_controller/templates/index.html
@@ -18,10 +18,10 @@
 </head>
 <body>
 
-{% for output in range(1, matrix.num_outputs+1) %}
+{% for output in range(1, matrix.outputs+1) %}
 <select class="target" id="output_{{output}}">
-{% for input in range(1, matrix.num_inputs+1) %}
-   <option value="{{input}}"{% if matrix.getOutput(output)==input %} selected="selected"{% endif %}>{{input}}</option>
+{% for input in range(1, matrix.inputs+1) %}
+   <option value="{{input}}"{% if matrix.read(output-1)==input-1 %} selected="selected"{% endif %}>{{input}}</option>
 {% endfor %}
 </select>
 {% endfor %}

--- a/hdmi_matrix_controller/web.py
+++ b/hdmi_matrix_controller/web.py
@@ -83,7 +83,8 @@ class OutputPortList(Resource):
         """
         Returns the JSON representation of the driver.
         """
-        return driver.DRIVER.toJSON() # TODO
+        logging.info(driver.DRIVER.to_json())
+        return driver.DRIVER.to_json()
 
 
 API.add_resource(OutputPortList, "/outputs")


### PR DESCRIPTION
I've added a to_json() method that returns a JSON representation of the matrix driver. The /outputs endpoint calls this method.